### PR TITLE
Ensuring dnsmasq is on latest version

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
-package 'dnsmasq'
+package 'dnsmasq' do
+  action :upgrade
 
 include_recipe 'dnsmasq::dns' if node['dnsmasq']['enable_dns']
 include_recipe 'dnsmasq::dhcp' if node['dnsmasq']['enable_dhcp']


### PR DESCRIPTION
Exploits have been found in dnsmasq that requires the latest version of dnsmasq. This ensures dnsmasq is installed to the latest available production version.